### PR TITLE
attempt at reorganizing DS teacher resource page

### DIFF
--- a/pathways/data-science/langs/en-us/resources/index.adoc
+++ b/pathways/data-science/langs/en-us/resources/index.adoc
@@ -1,76 +1,66 @@
-= Teacher Resources
+== Teacher Resources
 
-++++
-<style>
-.sect1 { border-top: 1px solid #efefed; }
-</style>
-++++
-
-- *Exercises and Solutions* - <<Exercises and Solutions, Jump to Exercises and Solutions>>
-
-- *Starter Files* - <<Starter Files, Jump to Starter Files>>
-
-- *Projects* - <<Projects, Jump to Projects>>
-
-- *Contracts* [@link{solution-pages/contracts.pdf, file}] - a reference PDF of just the contracts pages from the back of the student workbook.
-
-- *Implementation Options* - looking to integrate Bootstrap:Data Science into your classroom? There are @link{pages/implementation-options.adoc, implementation guides} for teachers looking to fill a week's worth of time, or a full-year course!
-
-- *Online Community (Discourse)* [@link{https://discourse.bootstrapworld.org/, link}] - Want to ask a question or pose a lesson idea for other Bootstrap teachers? Want to see resources other teachers are making and sharing? Our discussion forum is the place to do it.
-
-- *Workshop Files* - <<Workshop Files, Jump to Workshop Files>>
-
-- *Collection of Bootstrap:Data Science Desmos Activities* [@link{https://teacher.desmos.com/collection/5fc9250afcaa3f30f4946746, link}] - Love Desmos as much as we do? We have plenty of Desmos activities infused throughout our Data Science lessons, and you can explore all of them in one place.
-
-- *What's Going on in this Graph?* [@link{https://www.nytimes.com/column/whats-going-on-in-this-graph, nytimes.com}] - Once a week, the NYTimes posts an interesting data visualization. This is a great resource to spark the curiosity of young data scientists, and make for a perfect Notice &amp; Wonder activity!
-
-- *The Pudding* [@link{https://pudding.cool/, link}] - Terrific deep dives into data analysis for interesting topics. Another wonderful resource for students, with great animations showing the transformation of how data is visualized as the research questions evolve.
-
-- *"How Not To"* [@link{https://discourse.bootstrapworld.org/t/something-fun-for-the-classroom-hownotto/1459/9, Discourse.org}] - We regularly post to social media under the hashtag `#HowNotTo`, taking a few friendly potshots at examples of terrible Data Science out there. Over on our teacher discussion board, we've kept a running tally of all of them!
-
-- *"Same Stats, Different Graphs"* - [@link{https://www.autodesk.com/research/publications/same-stats-different-graphs, autodesk.com}] - A wonderful illustration of why it's so important to see the _shape_ of data, and not just focus on the descriptive statistics.
-
-- *Guess the Correlation* [@link{http://guessthecorrelation.com/, link}] - a game-ified resource for building intuition for correlation, based on randomly-generated scatterplots.
-
-- *Box Plots and Histograms* [@link{https://code.pyret.org/editor#share=1q_yHgXVUHMeqVfdEuWotGXy4k149ecqZ&v=1904b2c, link}] This starter file is designed such that the data in each column has a different shape and spread to support teachers looking to facilitate class discussions with a wide range of examples readily available at once.
-
-== Workshop Files
-
-- @link{https://docs.google.com/forms/d/e/1FAIpQLScaKOQ1L0Ni-sVuMY9tRhbAFcAcSFLA28lqPXQAJ03cUkSYYg/viewform, Pre-PD Survey} - Please fill out this survey prior to your first day.
-- @link{https://docs.google.com/forms/d/1Jawbr4NMpSTAb6O-Bn-dPL17_0uZt55NZqf8Z9C555E/viewform, Post-PD Survey} - Give us some feedback!
+- *Teacher Edition* [PDF] - A downloadable and printable teacher's guide with paced out lesson plans and facilitation tips.
+- *Teacher Answer Key* [PDF] -  A downloadable and printable copy of the workbook with solutions for all exercises.
+- *Online Community (Discourse)* [@link{https://discourse.bootstrapworld.org/, link}] - Talk with other Bootstrap teachers, ask questions, and share out ideas!
+- *Collection of Bootstrap:Data Science Desmos Activities* [@link{https://teacher.desmos.com/collection/5fc9250afcaa3f30f4946746, link}] - All of our Desmos Data Science lessons, in one place.
 
 == Starter Files
 
 - @link{https://docs.google.com/spreadsheets/d/1VeR2_bhpLvnRUZslmCAcSRKfZWs_5RNVujtZgEl6umA/, Animals Dataset}
+
 - @link{https://code.pyret.org/editor#share=1TaT71hwwL5WgR7F_2gHHeS7doyV_ncoZ&v=a3ffc15, Animals Starter File}
+
 - @link{https://code.pyret.org/editor#share=1bGC-RCZhH4mFe-vzrrvQcCj6Y83swJYj&v=a3ffc15, Animals Starter File - Part 2}
+
 - @link{https://code.pyret.org/editor#share=1IWPbJK_hsxIGtbUJLz59tLeL_NE1p9FG&v=a3ffc15, Table Methods Starter File}
-- @link{https://code.pyret.org/editor#share=1VVz4l0P6GLwbcpYyAGYJuRgBxj69R52Z, the Trust-but-Verify Starter File}
-- @link{https://www.geogebra.org/m/ZcVIxKtF, Playing with Predictors}
 
-== Exercises and Solutions
+- @link{https://code.pyret.org/editor#share=1VVz4l0P6GLwbcpYyAGYJuRgBxj69R52Z, Trust-but-Verify Starter File}
 
-@all-exercises
+- @link{https://code.pyret.org/editor#share=1q_yHgXVUHMeqVfdEuWotGXy4k149ecqZ&v=1904b2c, Box Plots and Histograms Starter File}
 
-== Facilitation Support
-- @link{https://docs.google.com/forms/d/e/1FAIpQLSfj24nCBA18zvjK19OwS_DZfwFZpHoPtPcd-2ADiUDfevkaSA/viewform, Homework Submission Template}
+== Mini Projects
 
-- *Broadening Participation* [@link{https://docs.google.com/presentation/d/17uEl-yS2smjSuOdDLJPzMWWffeXTqBsENjAaZe_qkso/view, Google Slides}] - Making computing relevant, accessible and welcoming to all students isn't a pipe-dream. Like anything else worth doing, it takes some good practice and a desire to do it right and keep improving. We've put together some pointers based on best-practices from the CS-Education literature, for Bootstrap teachers or anyone looking to broaden participation in Computer Science.
+- @link{../lessons/displaying-categorical-data/pages/infographics.adoc, Making Infographics} & @link{../lessons/displaying-categorical-data/pages/infographic-rubric.adoc, Rubric} - Students develop a ratio statement from a dataset of their choice, and then illustrate it via a compelling infographic.
 
-== Projects
+- @link{../lessons/random-samples/pages/food-habits-project.adoc, Food Habits Project} - Students analyze their snacking habits in comparison with data on childhood obesity in the U.S.
 
-=== Mini Projects
+- @link{../lessons/random-samples/pages/time-use-project.adoc, Time Use Project} - Students investigate the amount of time they spend interacting with technology and doing homework as compared with other Americans.
 
-- @link{../lessons/displaying-categorical-data/pages/infographics.adoc, Making Infographics}
-- @link{../lessons/displaying-categorical-data/pages/infographic-rubric.adoc, Making Infographics Rubric}
-- @link{../lessons/random-samples/pages/food-habits-project.adoc, Food Habits Project}
-- @link{../lessons/random-samples/pages/time-use-project.adoc, Time Use Project}
-- @link{../lessons/threats-to-validity/pages/threats-to-validity-project.adoc, Threats to Validity Project}
+- @link{../lessons/threats-to-validity/pages/threats-to-validity-project.adoc, Threats to Validity Project} - Students pretend to be terrible data scientists who develop and support a claim based on faulty sampling techniques (selection bias, sample size problems, sampling errors, confounding variables).
 
-=== Research Paper Files
+== Resources that Pair Well with Bootstrap:Data Science
+
+- @link{https://www.nytimes.com/column/whats-going-on-in-this-graph, What's Going on in this Graph?} - weekly intriguing data visualizations by the New York Times
+
+- @link{https://pudding.cool/, The Pudding} - fascinating, data-rich visual essays explaining ideas debated in culture
+
+- @link{https://discourse.bootstrapworld.org/t/something-fun-for-the-classroom-hownotto/1459/9, How Not To} - friendly potshots at terrible Data Science, regularly posted to social media under the hashtag "HowNotTo"
+
+- @link{https://www.autodesk.com/research/publications/same-stats-different-graphs, Same Stats, Different Graphs} - an illustration from Autodesk of why we must see the shape of data and not just focus on the descriptive statistics
+
+- @link{http://guessthecorrelation.com/, Guess the Correlation} - a game-ified resource (built by Omar Wagih) for building intuition for correlation, based on randomly-generated scatterplots
+
+- @link{https://www.geogebra.org/m/ZcVIxKtF, Sensitive r} - an applet from Geogebra that shows how changing a single point can change the correlation coefficient r
+
+
+== Research Paper Files
 
 Every student (or, ideally, every __pair__ of students) will need to save a copy of the @link{https://docs.google.com/document/d/1_ZEIgM4zvxI7JizViVFZojnpd3Yr2rYe8puPk8pjOcs/copy, Blank Research Paper}. A @link{pages/final-paper-rubric.adoc, Grading Rubric} is also available for the research paper.
 
 @include{../lessons/choosing-your-dataset/fragments/dataset-table.adoc}
 
 Students can also import their data into a @link{https://code.pyret.org/editor#share=12v7kzbxHt2LaSe2uI2d_OnssxtTNF0A8, Blank Starter File}. They will need to modify this file for use with their dataset, and @link{https://www.youtube.com/watch?v=K4n9hTSqcyw, this tutorial video} can walk them through it.
+
+== Exercises and Solutions
+
+@all-exercises
+
+== Other Facilitation Resources
+- *Implementation Options* - Looking to integrate Bootstrap:Data Science into your classroom? This @link{pages/implementation-options.adoc, implementation guides} includes suggestions for teachers looking to fill a week's worth of time, or a full-year course!
+
+- *Contracts* - a reference @link{solution-pages/contracts.pdf, PDF} of the contracts pages from the back of the student workbook
+
+- *Homework Submission Template* - Use this @link{https://docs.google.com/forms/d/e/1FAIpQLSfj24nCBA18zvjK19OwS_DZfwFZpHoPtPcd-2ADiUDfevkaSA/viewform, google form} to efficiently collect hyperlinks to student work.
+
+- *Broadening Participation* [@link{https://docs.google.com/presentation/d/17uEl-yS2smjSuOdDLJPzMWWffeXTqBsENjAaZe_qkso/view, Google Slides}] - Making computing relevant, accessible and welcoming to all students isn't a pipe-dream. Like anything else worth doing, it takes some good practice and a desire to do it right and keep improving. We've put together some pointers based on best-practices from the CS-Education literature, for Bootstrap teachers or anyone looking to broaden participation in Computer Science.


### PR DESCRIPTION
Here's an attempt at reorganizing the DS teacher resource page!

The branch name is ds-teacher-resource 

Some notes:
- The first few bullets include redundancies because the asciidoc automatically included links to "Teacher Workbook" and "PD Workbook". (I propose that we refer to these as "Teacher Edition" and "Teacher Answer Key" instead; those names automatically carry distinct meanings to teachers, whereas the terms we are using do not, and are - in my opinion - a bit confusing.) I think Dorai might need to do some work to fix these links so that they are automated?

I also removed the PD pre/post surveys as I do not think they belong on this page. I know that @flannery-denny agrees with this; @schanzer , if it's important to you that they stay, let me know. 

If Dorai develops a new project directive, I would use that too.