### PR TITLE
Collapsible Exercises and Solutions 

### DIFF
--- a/lib/bootstraplesson.js
+++ b/lib/bootstraplesson.js
@@ -372,9 +372,10 @@ function populateLesson() {
         bullet.firstChild.innerHTML += ` from the <a href="${href}">Student Workbook</a>`;
       }
       // Add the triangle to open and close the pageSublist
-      const openCloseWidgetHTML = `<span class="showPageLinks">
-        <a href="javascript:showPageLinks(${optPages})"></a></span>`;
-      bullet.children[0].innerHTML += openCloseWidgetHTML;
+      const openCloseWidget = document.createElement('span');
+      openCloseWidget.className = "showPageLinks";
+      openCloseWidget.innerHTML = `<a onclick="togglePageLinks(this);"></a>`
+      bullet.children[0].appendChild(openCloseWidget);
     }
 
     // REQUIRED: build the collapsible page list, then
@@ -587,9 +588,9 @@ function populateLesson() {
   }
 }
 
-function showPageLinks(optPages) {
-  const pagesLink = document.querySelector(`a[href^="javascript:downloadLessonPDFs(${optPages})"]`);
-  pagesLink.parentNode.classList.toggle("open");
+function togglePageLinks(node, optPages) {
+  const grandparent = node.parentNode.parentNode;
+  grandparent.classList.toggle("open");
 }
 
 // if there's a proglang suffix, remove it
@@ -845,19 +846,24 @@ function populateTeacherResources() {
   const solutions = document.querySelector('#exercises_and_solutions');
   lessons.forEach(l => {
     const lessonDiv = document.createElement('div');
+    lessonDiv.className = "materials-links";
     const allPages = graph[l].pages.concat(graph[l].optPages);
-    lessonDiv.innerHTML = `<a style="font-weight:bold;" href="../../../lessons/${l}">${graph[l].title}</a>`
-    // Add the triangle to open and close the pageSublist
-    const openCloseWidgetHTML = `<span class="showPageLinks">
-      <a href="javascript:this.parentNode.classList.toggle('active')"></a></span>`;
-    lessonDiv.innerHTML += openCloseWidgetHTML;
-
-    lessonDiv.innerHTML += `<div class="ulist"><ul>` + allPages.map(({fileName, title}) => 
-      `<li>${title} <span class="pageNum">[
-      <a href="../../../${l}/pages/${fileName.replace('adoc', 'html')}">exercise</a> |  
-      <a href="../../../${l}/solution-pages/${fileName.replace('adoc', 'html')}">solution</a>
-      ]</span>`
-      ).join('') + `</ul></div>`;
+    const paragraph = document.createElement('p');
+    paragraph.innerHTML = `<a style="font-weight:bold;" href="../../../lessons/${l}">${graph[l].title}</a>`
+    const openCloseWidget = document.createElement('span');
+    openCloseWidget.className = "showPageLinks";
+    openCloseWidget.innerHTML = `<a onclick="togglePageLinks(this);"></a>`
+    paragraph.appendChild(openCloseWidget);
+    lessonDiv.appendChild(paragraph)
+    // Add the lesson link and open/close triangle
+    lessonDiv.innerHTML += `
+      <div class="ulist"><ul>` + allPages.map(({fileName, title}) => 
+        `<li>${title} <span class="pageNum">[
+        <a href="../../../${l}/pages/${fileName.replace('adoc', 'html')}">exercise</a> |  
+        <a href="../../../${l}/solution-pages/${fileName.replace('adoc', 'html')}">solution</a>
+        ]</span></li>`)
+        .join('') + `</ul>
+      </div>`;
     solutions.appendChild(lessonDiv)
   });
 }

--- a/lib/bootstraplesson.js
+++ b/lib/bootstraplesson.js
@@ -846,21 +846,25 @@ function populateTeacherResources() {
   const solutions = document.querySelector('#exercises_and_solutions');
   lessons.forEach(l => {
     const lessonDiv = document.createElement('div');
-    lessonDiv.className = "materials-links";
-    const allPages = graph[l].pages.concat(graph[l].optPages);
     const paragraph = document.createElement('p');
-    paragraph.innerHTML = `<a style="font-weight:bold;" href="../../../lessons/${l}">${graph[l].title}</a>`
     const openCloseWidget = document.createElement('span');
+    const lessonPath = `../../../lessons/${l}`;
+    const allPages = graph[l].pages.concat(graph[l].optPages);
     openCloseWidget.className = "showPageLinks";
     openCloseWidget.innerHTML = `<a onclick="togglePageLinks(this);"></a>`
+    if(allPages.length == 0) {
+      openCloseWidget.innerHTML = ` (no exercises)`;
+    }
+    lessonDiv.className = "materials-links";
+    paragraph.innerHTML = `<a style="font-weight:bold;" href="${lessonPath}">${graph[l].title}</a>`
     paragraph.appendChild(openCloseWidget);
     lessonDiv.appendChild(paragraph)
     // Add the lesson link and open/close triangle
     lessonDiv.innerHTML += `
       <div class="ulist"><ul>` + allPages.map(({fileName, title}) => 
         `<li>${title} <span class="pageNum">[
-        <a href="../../../${l}/pages/${fileName.replace('adoc', 'html')}">exercise</a> |  
-        <a href="../../../${l}/solution-pages/${fileName.replace('adoc', 'html')}">solution</a>
+        <a href="${lessonPath}/pages/${fileName.replace('adoc', 'html')}">exercise</a> |  
+        <a href="${lessonPath}/solution-pages/${fileName.replace('adoc', 'html')}">solution</a>
         ]</span></li>`)
         .join('') + `</ul>
       </div>`;

--- a/lib/bootstraplesson.js
+++ b/lib/bootstraplesson.js
@@ -379,7 +379,7 @@ function populateLesson() {
 
     // REQUIRED: build the collapsible page list, then
     // add other bullets+links for starter files, glossary, slide deck, and PDF
-    const requiredContainer = document.querySelectorAll(`.materials-links`)[0];
+    const requiredContainer = document.querySelector(`#material-links`);
     initializeContainer(requiredContainer, false, "PDF of all Handouts and Pages");
     const requiredMaterials = requiredContainer.querySelector('ul');
     makeCollapsiblePageList(requiredMaterials, false);   
@@ -397,7 +397,8 @@ function populateLesson() {
     requiredMaterials.innerHTML += otherBulletsHTML;
 
     // OPTIONAL: build the collapsible page list, then add contracts reference
-    const optContainer = document.querySelectorAll(`.materials-links`)[1];
+    const optContainer = document.querySelector(`#opt-material-links`);
+    if(!optContainer) { return; } // not every page has optional materials
     initializeContainer(optContainer, true, "Additional Printable Pages for Scaffolding and Practice")
     const optMaterials = optContainer.querySelector('ul');
     makeCollapsiblePageList(optMaterials, true);
@@ -542,7 +543,7 @@ function populateLesson() {
   } catch (e) { console.log('checkPathwaySpecificContent', e); }
   try { 
     populateMaterials(priorData);     
-  } catch (e) { console.log('addPageNums', e); }
+  } catch (e) { console.log('populateMaterials', e); }
   try { 
     // only compute prereqs for the currently-active lesson
     addPrereqs(computeTransitiveData(lesson, false, false).prerequisites);  
@@ -803,15 +804,15 @@ function populateTeacherResources() {
   const container = document.querySelector('#lesson-info-table');
   const table = document.createElement("table");
   table.innerHTML = `
-  <thead>
-    <tr>
-      <th>Lesson</th>
-      <th>Slides & Notes</th>
-      <th>Starter Files</th>
-    </tr>
-  </thead>
-  <tbody>
-  </tbody>`;
+    <thead>
+      <tr>
+        <th>Lesson</th>
+        <th>Slides & Notes</th>
+        <th>Starter Files</th>
+      </tr>
+    </thead>
+    <tbody>
+    </tbody>`;
   const data = computeTransitiveData(lesson, pathway, lessons);
   const tbody = table.querySelector('tbody');
   const proglang = graph[lessons[0]].proglang;
@@ -840,6 +841,25 @@ function populateTeacherResources() {
     tbody.appendChild(row);
   })
   container.appendChild(table);
+
+  const solutions = document.querySelector('#exercises_and_solutions');
+  lessons.forEach(l => {
+    const lessonDiv = document.createElement('div');
+    const allPages = graph[l].pages.concat(graph[l].optPages);
+    lessonDiv.innerHTML = `<a style="font-weight:bold;" href="../../../lessons/${l}">${graph[l].title}</a>`
+    // Add the triangle to open and close the pageSublist
+    const openCloseWidgetHTML = `<span class="showPageLinks">
+      <a href="javascript:this.parentNode.classList.toggle('active')"></a></span>`;
+    lessonDiv.innerHTML += openCloseWidgetHTML;
+
+    lessonDiv.innerHTML += `<div class="ulist"><ul>` + allPages.map(({fileName, title}) => 
+      `<li>${title} <span class="pageNum">[
+      <a href="../../../${l}/pages/${fileName.replace('adoc', 'html')}">exercise</a> |  
+      <a href="../../../${l}/solution-pages/${fileName.replace('adoc', 'html')}">solution</a>
+      ]</span>`
+      ).join('') + `</ul></div>`;
+    solutions.appendChild(lessonDiv)
+  });
 }
 
 /*******************************************

--- a/lib/bootstraplesson.js
+++ b/lib/bootstraplesson.js
@@ -300,8 +300,12 @@ function computeTransitiveData(lesson, pathway, lessons = false) {
     return ({
       pathway: pathway,
       titles: acc.titles.concat([l]).filter(onlyUnique),
-      pages: graph[l].pages.map(p => formatPageURL(p, l)).concat(acc.pages),
-      optPages: graph[l].optPages.map(p => formatPageURL(p, l)).concat(acc.optPages),
+      pages: graph[l].pages.map(({fileName, title}) => {
+        return {fileName:formatPageURL(fileName, l), title: title};
+      }).concat(acc.pages),
+      optPages: graph[l].optPages.map(({fileName, title}) => {
+        return {fileName:formatPageURL(fileName, l), title: title};
+      }).concat(acc.optPages),
       primitives: graph[l].primitives.concat(acc.primitives).filter(onlyUnique),
       prerequisites: graph[l].prerequisites.concat(acc.prerequisites).filter(onlyUnique),
       starterFiles: graph[l].starterFiles.concat(acc.starterFiles).filter(onlyUnique),
@@ -324,37 +328,84 @@ function computeTransitiveData(lesson, pathway, lessons = false) {
 // in the dependency graph
 function populateLesson() {
 
-  function addPageNums(priorData) {
-    const { pathway, lessons, lesson, proglang } = getParams();
-    const pagesLink = document.querySelector(`a[href^="javascript:downloadLessonPDFs(false)"]`);
-    const pagesContainer = pagesLink.parentNode;
-    let lowIndex, highIndex;
-    const printables = ".PrintableExercise:not(.Optional)";
-    [...document.querySelectorAll(printables)].forEach((span) => {
-      link = span.querySelector("a");
-      const path = link.getAttribute("href");
-      const index = priorData.pages.indexOf(path) + 1;
-      if (index < 1) console.error(`link ${link} does not match a workbook page`);
-      if (!lowIndex  || index <= lowIndex) lowIndex  = index;
-      if (!highIndex || index > highIndex) highIndex = index;
-      if(priorData.pathway) { // add pagenums for a pathway
-        span.parentNode.innerHTML += `<span class="pageNum">(Page ${index})</span>`;
-      }
-    });
-    
-    // If there's a pathway, add link to student workbook for required pages
-    if(pathway) {
-      const txt = document.createTextNode("from the ");
-      const link = document.createElement('a');
-      link.href = "../../courses/"+pathway+"/workbook/workbook.pdf";
-      link.innerHTML = "Student Workbook";
-      pagesContainer.insertBefore(txt,  pagesContainer.lastChild);
-      pagesContainer.insertBefore(link, pagesContainer.lastChild);
-      if(lowIndex == highIndex) pagesLink.innerHTML += ` ${lowIndex}`;
-      else pagesLink.innerHTML += ` ${lowIndex}-${highIndex}`;
+  function populateMaterials(priorData) {
+    const { pathway, lesson, proglang } = getParams();
+    function initializeContainer(container, optPages, text) {
+      container.classList.add('ulist');
+      container.innerHTML = `
+      <ul><li>
+        <p><a href="javascript:downloadLessonPDFs(${optPages})">${text}</a></p>
+        <div class="ulist"><ul></ul></div>
+        </li>
+      </ul>`;
     }
-  }
 
+    function makeCollapsiblePageList(materialsList, optPages) {
+      const bullet = materialsList.children[0];
+      const pagesLink   = bullet.querySelector('a');
+      const pageSublist = bullet.querySelector('ul');
+      const pageList = optPages? graph[lesson].optPages : graph[lesson].pages;
+      // For every page, add a link and keep track of page numbers and page ranges
+      let lowIndex, highIndex;
+      pageList.forEach(({fileName:path, title:text}) => {
+        path = formatPageURL(path, lesson);
+        const index = priorData.pages.findIndex(({fileName, title}) => fileName == path) + 1;
+        let html = `<li><span class="PrintableExercise ${optPages? "Optional" : ""}">
+          <a href="${path}" target="_blank" rel="noopener">${text}</a></span>` 
+        if(priorData.pathway && !optPages) {
+          html += `<span class="pageNum">(Page ${index})</span>`;
+        }
+        html += `</li>`;
+        if ((index < 1) && !optPages) {
+          console.error(`link ${path} does not match a workbook page`);
+        }
+        if (!lowIndex  || index <= lowIndex) lowIndex  = index;
+        if (!highIndex || index > highIndex) highIndex = index;
+        pageSublist.innerHTML += html;
+      });
+
+      // If there's a pathway, add link to student workbook for required pages
+      if(pathway && !optPages) {
+        if(lowIndex == highIndex) pagesLink.innerHTML += ` ${lowIndex}`;
+        else pagesLink.innerHTML += ` ${lowIndex}-${highIndex}`;
+        const href = "../../courses/"+pathway+"/workbook/workbook.pdf";
+        bullet.firstChild.innerHTML += ` from the <a href="${href}">Student Workbook</a>`;
+      }
+      // Add the triangle to open and close the pageSublist
+      const openCloseWidgetHTML = `<span class="showPageLinks">
+        <a href="javascript:showPageLinks(${optPages})"></a></span>`;
+      bullet.children[0].innerHTML += openCloseWidgetHTML;
+    }
+
+    // REQUIRED: build the collapsible page list, then
+    // add other bullets+links for starter files, glossary, slide deck, and PDF
+    const requiredContainer = document.querySelectorAll(`.materials-links`)[0];
+    initializeContainer(requiredContainer, false, "PDF of all Handouts and Pages");
+    const requiredMaterials = requiredContainer.querySelector('ul');
+    makeCollapsiblePageList(requiredMaterials, false);   
+
+    let otherBulletsHTML = "";
+    graph[lesson].starterFiles.forEach(name => {
+      if (["program-list", "editor"].includes(name)) return; // skip program-list and editor
+      const file = starterFiles[name];
+      otherBulletsHTML += `<li><p><a href="${file[proglang].url}">${file['title']}</a></p></li>`
+    })
+    otherBulletsHTML += `
+      <li><p><a href="../../Glossary.shtml?lesson=${lesson}">Lesson Glossary</a></p></li>
+      <li><p><a href="${graph[lesson].slides}">Lesson Slides</a></p></li>
+      <li><p><a href="index.pdf">Printable Lesson Plan</a> (a PDF of this web page)</p></li>`;
+    requiredMaterials.innerHTML += otherBulletsHTML;
+
+    // OPTIONAL: build the collapsible page list, then add contracts reference
+    const optContainer = document.querySelectorAll(`.materials-links`)[1];
+    initializeContainer(optContainer, true, "Additional Printable Pages for Scaffolding and Practice")
+    const optMaterials = optContainer.querySelector('ul');
+    makeCollapsiblePageList(optMaterials, true);
+    optMaterials.innerHTML += `
+      <li><p><a href="../../Contracts.shtml?pathway=${pathway}">Contracts Reference</p></li>`
+
+  }
+  /*
   function makeLangTable(priorData, proglang) {
     // if there aren't any primitives, don't show the langTable link at all
     if(priorData.primitives.length == 0) {
@@ -404,7 +455,7 @@ function populateLesson() {
     langTableContents = makeContents(priorData.primitives);
     document.body.appendChild(langTableContents);
   }
-
+  */
   // use the entire pathway or custom lesson list (if we have it)
   // otherwise use sorted prereqs
   function buildLessonSidebar(lesson, pathway, priorData) {
@@ -473,14 +524,14 @@ function populateLesson() {
   }
   // get prior data for every lesson in the pathway (or prereqs, if pathway is false)
   const priorData = computeTransitiveData(lesson, pathway, lessons);
-  
+  /*
   console.log(
     "pathway is", pathway, 
     "lesson is", lesson,
     "pathwayLessons are", pathwayTocs[pathway], 
     "prior lessons are", priorData.titles,
     "prior data is", priorData);
-  
+  */
 
   // If pathway is defined, add the title
   try {
@@ -490,7 +541,7 @@ function populateLesson() {
     checkPathwaySpecificContent(pathway); // show/hide pathway-specific content
   } catch (e) { console.log('checkPathwaySpecificContent', e); }
   try { 
-    addPageNums(priorData);     
+    populateMaterials(priorData);     
   } catch (e) { console.log('addPageNums', e); }
   try { 
     // only compute prereqs for the currently-active lesson

--- a/lib/bootstraplesson.js
+++ b/lib/bootstraplesson.js
@@ -844,6 +844,7 @@ function populateTeacherResources() {
   container.appendChild(table);
 
   const solutions = document.querySelector('#exercises_and_solutions');
+  solutions.innerHTML = ""; // empty the div
   lessons.forEach(l => {
     const lessonDiv = document.createElement('div');
     const paragraph = document.createElement('p');

--- a/lib/maker/make-dependency-graph.lua
+++ b/lib/maker/make-dependency-graph.lua
@@ -38,6 +38,11 @@ local function read_slidesURL(slidesId_file)
   return 'https://docs.google.com/presentation/d/' .. id
 end
 
+
+
+    
+
+
 local o = io.open(graph_file, 'w+')
 
 o:write('var graph = {\n')
@@ -66,6 +71,15 @@ for _,lesson in ipairs(lessons) do
     i:close()
   end
   --
+  local function page_title(page_adoc_file)
+    local title_file = lessonpagecache .. '.' .. page_adoc_file:gsub('%.adoc', '') .. '.titletxt'
+    local title = page_adoc_file
+    if file_exists_p(title_file) then
+      local title2 = first_line(title_file)
+      if title2 then title = title2 end
+    end
+    return title
+  end
   --
   local title_file = lessoncache .. '.index.titletxt'
   local description_file = lessoncache .. '.index-desc.txt.kp'

--- a/lib/maker/make-dependency-graph.lua
+++ b/lib/maker/make-dependency-graph.lua
@@ -38,6 +38,11 @@ local function read_slidesURL(slidesId_file)
   return 'https://docs.google.com/presentation/d/' .. id
 end
 
+
+
+    
+
+
 local o = io.open(graph_file, 'w+')
 
 o:write('var graph = {\n')
@@ -66,6 +71,15 @@ for _,lesson in ipairs(lessons) do
     i:close()
   end
   --
+  local function page_title(page_adoc_file)
+    local title_file = lessonpagecache .. '.' .. page_adoc_file:gsub('%.adoc', '') .. '.titletxt'
+    local title = page_adoc_file
+    if file_exists_p(title_file) then
+      local title2 = first_line(title_file)
+      if title2 then title = title2 end
+    end
+    return title
+  end
   --
   local title_file = lessoncache .. '.index.titletxt'
   local description_file = lessoncache .. '.index-desc.txt.kp'
@@ -107,7 +121,7 @@ for _,lesson in ipairs(lessons) do
   if file_exists_p(pages_file) then
     i = io.open(pages_file)
     for line in i:lines() do
-      pages_txt = pages_txt .. '\"' .. line .. '\", '
+      pages_txt = pages_txt .. '[ \"' .. line .. '\", \"' .. page_title(line) .. '\"], '
     end
     i:close()
   end
@@ -115,7 +129,7 @@ for _,lesson in ipairs(lessons) do
   if file_exists_p(exercisePages_file) then
     i = io.open(exercisePages_file)
     for line in i:lines() do
-      exercisePages_txt = exercisePages_txt .. '\"' .. line .. '\", '
+      exercisePages_txt = exercisePages_txt .. '[ \"' .. line .. '\", \"' .. page_title(line) .. '\"], '
     end
     i:close()
   end

--- a/lib/maker/make-dependency-graph.lua
+++ b/lib/maker/make-dependency-graph.lua
@@ -121,7 +121,7 @@ for _,lesson in ipairs(lessons) do
   if file_exists_p(pages_file) then
     i = io.open(pages_file)
     for line in i:lines() do
-      pages_txt = pages_txt .. '[ \"' .. line .. '\", \"' .. page_title(line) .. '\"], '
+      pages_txt = pages_txt .. '{fileName: \"' .. line .. '\", title:\"' .. page_title(line) .. '\"}, '
     end
     i:close()
   end
@@ -129,7 +129,7 @@ for _,lesson in ipairs(lessons) do
   if file_exists_p(exercisePages_file) then
     i = io.open(exercisePages_file)
     for line in i:lines() do
-      exercisePages_txt = exercisePages_txt .. '[ \"' .. line .. '\", \"' .. page_title(line) .. '\"], '
+      exercisePages_txt = exercisePages_txt .. '{fileName: \"' .. line .. '\", title:\"' .. page_title(line) .. '\"}, '
     end
     i:close()
   end

--- a/lib/preproc.rkt
+++ b/lib/preproc.rkt
@@ -1584,8 +1584,7 @@
                               (error 'ERROR
                                      "WARNING: @material-links (~a, ~a) valid only in lesson plan"
                                      *lesson-subdir* *in-file*))
-                            (fprintf o "\ninclude::~a/{cachedir}.index-extra-mat.asc[]\n\n"
-                                     *containing-directory*)
+                            (fprintf o "\n&nbsp;\n")
                             ; The line below can be deleted, once langTable links are generated via their own directive
                             #;(when (member *proglang* '("pyret" "wescheme"))
                               (fprintf o "* *Classroom visual:* link:javascript:showLangTable()[Language Table]"))]
@@ -1595,9 +1594,7 @@
                                      "WARNING: @opt-material-links (~a, ~a) valid only in lesson plan"
                                      *lesson-subdir* *in-file*))
                             (set! *supplemental-materials-needed?* #t)
-                            (fprintf o "\ninclude::~a/{cachedir}.index-extra-opt-mat.asc[]\n\n"
-                                     *containing-directory*)
-                             ]
+                            (fprintf o "\n&nbsp;\n")]
                            [(string=? directive "language-table")
                             (let ([link-text (string-trim (read-group i directive))])
                               (unless *lesson-plan*
@@ -2204,7 +2201,7 @@
         (call-with-output-file (path-replace-extension *out-file* "-extra-mat.asc")
           (lambda (o)
             ; REQUIRED PRINTABLE PAGES
-            (unless (and (empty? *handout-exercise-links*) (empty? *printable-exercise-links*))
+            #;(unless (and (empty? *handout-exercise-links*) (empty? *printable-exercise-links*))
               (fprintf o "\n* link:javascript:downloadLessonPDFs(false)[PDF of all Handouts and Pages]")
               (fprintf o " [.showPageLinks]#link:javascript:showPageLinks(false)[ ]#")
               (for ([x (reverse *handout-exercise-links*)])
@@ -2227,7 +2224,7 @@
               (fprintf o "\n* ~a\n\n" x))
             ; ONLINE EXERCISES --- to be removed onces all required online exercises
             ; have been turned into starter files
-            (for ([x (map cdr (reverse *online-exercise-links*))])
+            #;(for ([x (map cdr (reverse *online-exercise-links*))])
               (fprintf o "\n* ~a\n\n" x))
             ; SLIDES
             (display-lesson-slides o)

--- a/lib/preproc.rkt
+++ b/lib/preproc.rkt
@@ -1584,17 +1584,18 @@
                               (error 'ERROR
                                      "WARNING: @material-links (~a, ~a) valid only in lesson plan"
                                      *lesson-subdir* *in-file*))
-                            (fprintf o "\n&nbsp;\n")
+                            (fprintf o "\n[#material-links]\n&nbsp;\n")
                             ; The line below can be deleted, once langTable links are generated via their own directive
                             #;(when (member *proglang* '("pyret" "wescheme"))
-                              (fprintf o "* *Classroom visual:* link:javascript:showLangTable()[Language Table]"))]
+                              (fprintf o "* *Classroom visual:* link:javascript:showLangTable()[Language Table]"))
+                            ]
                            [(string=? directive "opt-material-links")
                             (unless *lesson-plan*
                               (error 'ERROR
                                      "WARNING: @opt-material-links (~a, ~a) valid only in lesson plan"
                                      *lesson-subdir* *in-file*))
                             (set! *supplemental-materials-needed?* #t)
-                            (fprintf o "\n&nbsp;\n")]
+                            (fprintf o "\n[#opt-material-links]\n&nbsp;\n")]
                            [(string=? directive "language-table")
                             (let ([link-text (string-trim (read-group i directive))])
                               (unless *lesson-plan*
@@ -1651,18 +1652,13 @@
                             (unless *teacher-resources*
                               (error 'ERROR
                                      "adoc-preproc: @all-exercises valid only in teacher resources"))
-                            (display-exercise-collation o)]
+                            (fprintf o "\n[#exercises_and_solutions]\n&nbsp;\n")]
                            [(string=? directive "all-projects")
                             ; (printf "doing all-projects ~a\n" (errmessage-context))
                             (unless *teacher-resources*
                               (error 'ERROR
-                                     "adoc-preproc: @all-exercises valid only in teacher resources"))
+                                     "adoc-preproc: @all-projects valid only in teacher resources"))
                             (link-to-opt-projects o)]
-                           [(string=? directive "all-lesson-notes")
-                            (unless *teacher-resources*
-                              (error 'ERROR
-                                     "adoc-preproc: @all-lesson-notes valid only in teacher resources"))
-                            (link-to-notes-pages o)]
                            [(string=? directive "lesson-info")
                             (unless *teacher-resources*
                               (error 'ERROR

--- a/lib/shared.less
+++ b/lib/shared.less
@@ -266,6 +266,24 @@ lines on some browsers */
 
 .vocab { font-weight: bold; font-style: italic; color: @font-color; }
 
+.materials-links p {
+  .showPageLinks a { 
+    text-decoration: none; 
+    &::after { content: ' ▼ '; }
+  }
+  &+.ulist { 
+    transition: 1s ease-in; max-height: 0; overflow: hidden; 
+    padding-left: 5px; margin: 0; font-style: italic; font-size: 10pt;
+    .pageNum { float: right; margin-right: 10%; }
+  }
+}
+.materials-links p.open {
+  .showPageLinks a::after { content: ' ▲ '; }
+  &+.ulist { transition: 1s ease-in; max-height: 1000px; }
+}
+
+
+
 /************************************************************************************
 * NARRATIVE PAGE STYLES
 */
@@ -313,22 +331,6 @@ lines on some browsers */
     }
     &.left-header tr td:nth-child(1) { background-color: #b7d893; }
     &.left-header tr td:nth-child(1) p { font-weight: bold; }
-
-    .materials-links li p {
-      .showPageLinks a { 
-        text-decoration: none; 
-        &::after { content: ' ▼ '; }
-      }
-      &+.ulist { 
-        transition: 1s ease-in; max-height: 0; overflow: hidden; 
-        padding-left: 5px; margin: 0; font-style: italic; font-size: 10pt;
-        .pageNum { float: right; margin-right: 10%; }
-      }
-    }
-    .materials-links li p.open {
-      .showPageLinks a::after { content: ' ▲ '; }
-      &+.ulist { transition: 1s ease-in; max-height: 1000px; }
-    }
 
     /* Custom materials link styles */ 
     .Optional::before, .OptProject::before, .handout::before { color: gray;}

--- a/pathways/data-science-codap/langs/en-us/resources/index.adoc
+++ b/pathways/data-science-codap/langs/en-us/resources/index.adoc
@@ -31,7 +31,7 @@ Projects allow exploration of data collected by students themselves or chosen fr
 == All Lesson Notes
 The student workbook includes notes for various lessons. You can access all of these notes by clicking the links below:
 
-@all-lesson-notes
+@lesson-info
 
 == Printables for Classroom Walls
 

--- a/pathways/data-science-foundations/langs/en-us/resources/index.adoc
+++ b/pathways/data-science-foundations/langs/en-us/resources/index.adoc
@@ -18,11 +18,10 @@
 == Exercises and Solutions
 @all-exercises
 
-== Notes and Slide Decks
-
+== Notes, Slides, and Starter Files
 The student workbook includes notes for various lessons. You can access all of these notes by clicking the links below:
 
-@all-lesson-notes
+@lesson-info
 
 == Projects
 

--- a/pathways/videogame/langs/en-us/resources/index.adoc
+++ b/pathways/videogame/langs/en-us/resources/index.adoc
@@ -14,11 +14,10 @@
 == Exercises and Solutions
 @all-exercises
 
-== Notes and Slide Decks
-
+== Notes, Slides, and Starter Files
 The student workbook includes notes for various lessons. You can access all of these notes by clicking the links below:
 
-@all-lesson-notes
+@lesson-info
 
 == Projects in Bootstrap:Algebra
 


### PR DESCRIPTION
I couldn't wrap my head around the more-important authoring issues today, but didn't want to be useless, so I went ahead and implemented #1965 , making the following changes:

1. Adds optional and required page titles and filepaths to the dependency graphs
2. Uses that information to dynamically populate the materials lists on lesson pages (one less thing happening statically!)
3. Uses that information to dynamnically populate the "exercises and solutions" section of the TR page
4. Aligns the DOM, CSS and JS for collapsible page lists so that collapsibility can be re-used for TR page
5. Makes the lessons under "exercises and solutions" collapsible, thereby implementing the issue

@retabak and @flannery-denny - can you take it for a spin? (reminder: open the _pathway page_ and then click "teacher resources", rather than opening TR page directly

@ds26gte this removes any need for the `materials` and `opt-materials` cache files. I suspect there's a decent amount of build code for creating and handling them that can now be removed.