### PR TITLE
preproc.rkt: set {fromlangroot} for all files, and have @dist-link use

### DIFF
--- a/lib/preproc.rkt
+++ b/lib/preproc.rkt
@@ -861,7 +861,8 @@
       (when (and (or (not link-text) (string=? link-text "")) page-title)
         (set! link-text page-title))
       (let ([link-output (format "link:~apass:[~a][~a~a]"
-                                 *dist-root-dir* f link-text
+                                 "{fromlangroot}"
+                                 f link-text
                                  (if *lesson-plan* ", window=\"&#x5f;blank\"" ""))])
         link-output))))
 
@@ -1112,7 +1113,6 @@
     (display title o)
     (newline o)
     (newline o)
-    (fprintf o "ifndef::fromlangroot[:fromlangroot: ~a]\n\n" *dist-root-dir*)
 
     (when (and *lesson-subdir* (not *lesson-plan*) (not *narrative*))
       (let ([lesson-title-file
@@ -2164,6 +2164,7 @@
                     [*narrative* (display "[.narrative]\n" o)]
                     [*solutions-mode?* (display "[.solution-page]\n" o)]
                     )
+              (fprintf o "ifndef::fromlangroot[:fromlangroot: ~a]\n\n" *dist-root-dir*)
 
               (expand-directives i o)
 


### PR DESCRIPTION
I thought we already merged this, no?